### PR TITLE
v1.1 Phase 2: Popup redesign  fast controls, status, and usability polish

### DIFF
--- a/content.js
+++ b/content.js
@@ -407,4 +407,81 @@
       startIfAllowed();
     }
   );
+
+  // Live updates via messages from popup/background
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    try {
+      if (message && message.type === 'SETTINGS_UPDATED') {
+        const prevEnabled = state.isEnabled;
+        const prevMode = state.detectionMode;
+        const prevInterval = state.detectionIntervalMs;
+
+        if (message.payload) {
+          if (typeof message.payload.isEnabled === 'boolean') state.isEnabled = message.payload.isEnabled;
+          if (typeof message.payload.tabPause === 'boolean') state.tabPause = message.payload.tabPause;
+          if (typeof message.payload.detectionMode === 'string') state.detectionMode = message.payload.detectionMode;
+          if (typeof message.payload.detectionIntervalMs === 'number') state.detectionIntervalMs = message.payload.detectionIntervalMs;
+        }
+
+        // Update tab pause listeners
+        // Simpler approach: re-run setup (listeners internally guard duplicates)
+        // For this phase, we won't remove old handlers explicitly beyond lifecycle connections.
+
+        // Apply changes to scheduler/lifecycle without reload
+        const wasActive = prevEnabled && !isWhitelistedUrl();
+        const shouldBeActive = state.isEnabled && !isWhitelistedUrl();
+
+        if (wasActive && !shouldBeActive) {
+          // Turn off
+          lifecycle.disconnect();
+          scheduler.stop();
+        } else if (!wasActive && shouldBeActive) {
+          // Turn on
+          lifecycle.connect();
+          scheduler.start();
+        } else if (shouldBeActive) {
+          // Still active; if mode/interval changed, restart scheduler to apply
+          if (prevMode !== state.detectionMode || prevInterval !== state.detectionIntervalMs) {
+            scheduler.stop();
+            scheduler.start();
+          }
+        }
+
+        sendResponse({ ok: true, applied: true });
+        return; // no async work
+      }
+
+      if (message && message.type === 'WHITELIST_STATUS_CHANGED') {
+        // If this tab's URL is whitelisted now, stop; if removed, start (if enabled)
+        const url = message.url || location.href;
+        const affected = typeof url === 'string' ? location.href.includes(url) || url.includes(location.href) : false;
+        if (!affected) {
+          sendResponse({ ok: true, applied: false });
+          return;
+        }
+
+        if (message.isWhitelisted) {
+          lifecycle.disconnect();
+          scheduler.stop();
+          sendResponse({ ok: true, applied: true, stopped: true });
+        } else {
+          if (state.isEnabled) {
+            lifecycle.connect();
+            scheduler.start();
+            sendResponse({ ok: true, applied: true, started: true });
+          } else {
+            sendResponse({ ok: true, applied: false });
+          }
+        }
+        return;
+      }
+
+      if (message && message.type === 'PING') {
+        sendResponse({ ok: true, alive: true });
+        return;
+      }
+    } catch (e) {
+      sendResponse({ ok: false, error: String(e) });
+    }
+  });
 })();

--- a/popup.html
+++ b/popup.html
@@ -29,34 +29,40 @@
 
         <!-- Home Tab -->
         <div class="tab-content active" id="home-content">
+            <div class="status-tile" id="statusTile" aria-live="polite">
+                <div class="status-icon-wrap" aria-hidden="true"><i id="statusTileIcon" class="fas fa-shield-alt"></i></div>
+                <div class="status-text">
+                    <div id="statusTitle" class="status-title">Protected: ON</div>
+                    <div id="statusSub" class="status-sub"></div>
+                </div>
+                <div id="detectionChip" class="chip" aria-label="Detection mode">Detection: Auto</div>
+            </div>
+
+            <div id="applyNote" class="apply-note" role="status" aria-live="polite" hidden>Changes applied after reload.</div>
+
             <div class="card">
                 <div class="card-title">Quick Controls</div>
                 <div class="setting-item">
                     <span class="setting-label">PiP Auto-Close</span>
                     <label class="toggle-switch">
-                        <input type="checkbox" id="pipToggle">
+                        <input type="checkbox" id="pipToggle" aria-label="PiP Auto-Close">
                         <span class="toggle-slider"></span>
                     </label>
                 </div>
                 <div class="setting-item">
-                    <span class="setting-label">Pause Video on Tab Switch</span>
+                    <span class="setting-label">Pause video on tab switch</span>
                     <label class="toggle-switch">
-                        <input type="checkbox" id="tabToggle">
+                        <input type="checkbox" id="tabToggle" aria-label="Pause video on tab switch">
                         <span class="toggle-slider"></span>
                     </label>
                 </div>
-            </div>
-
-            <div class="card">
-                <div class="card-title">Status</div>
-                <div id="statusIndicator" class="setting-item">
-                    <span class="setting-label">Protection Status</span>
-                    <div class="status-badge">
-                        <span id="statusText">Enabled</span>
-                        <span id="statusIcon" class="status-icon">
-                            <i class="fas fa-shield-alt"></i>
-                        </span>
-                    </div>
+                <div class="setting-item">
+                    <button id="whitelistToggleBtn" class="btn btn-secondary" aria-live="polite">Allow PiP on this page</button>
+                    <button id="snoozeBtn" class="btn btn-secondary" disabled title="Coming in Phase 3">Snooze PiP</button>
+                </div>
+                <div id="nonFbHelper" class="helper" hidden>
+                    Open Facebook to use controls.
+                    <button id="openFbBtn" class="btn btn-primary" aria-label="Open Facebook">Open Facebook</button>
                 </div>
             </div>
         </div>
@@ -64,16 +70,16 @@
         <!-- Settings Tab -->
         <div class="tab-content" id="settings-content">
             <div class="card">
-                <div class="card-title">Detection Settings</div>
-                <div class="settings-group">
-                    <div class="settings-group-title">Mode</div>
-                    <div class="setting-item">
-                        <span class="setting-label">Detection Speed</span>
-                        <select id="detectionMode">
-                            <option value="auto">Auto (recommended)</option>
-                            <option value="manual">Manual</option>
-                        </select>
-                    </div>
+                <div class="card-title">Detection Speed</div>
+                <div class="settings-group" role="radiogroup" aria-label="Detection Speed">
+                    <label class="radio">
+                        <input type="radio" name="detectionMode" id="modeAuto" value="auto">
+                        <span>Auto (recommended)</span>
+                    </label>
+                    <label class="radio">
+                        <input type="radio" name="detectionMode" id="modeManual" value="manual">
+                        <span>Manual</span>
+                    </label>
                 </div>
                 <div class="settings-group">
                     <div class="settings-group-title">Manual Interval</div>
@@ -82,34 +88,23 @@
                             <span>PiP Detection Speed</span>
                             <span class="slider-value"><span id="timerValue">1000</span>ms</span>
                         </label>
-                        <input type="range" id="timerSetting" min="200" max="3000" step="100" value="1000">
+                        <input type="range" id="timerSetting" min="200" max="3000" step="100" value="1000" aria-label="Manual detection interval">
                     </div>
-                    <small>In Auto mode, this slider is disabled. Faster detection may use more resources.</small>
+                    <small id="autoHelper">Auto adjusts speed dynamically.</small>
                 </div>
             </div>
 
             <div class="card">
-                <div class="card-title">Advanced Settings</div>
+                <div class="card-title">Whitelist (basic)</div>
                 <div class="advanced-settings">
                     <div class="setting-item">
-                        <span class="setting-label">Whitelist Mode</span>
-                        <label class="toggle-switch">
-                            <input type="checkbox" id="whitelistToggle">
-                            <span class="toggle-slider"></span>
-                        </label>
-                    </div>
-                    
-                    <div id="whitelistSection" style="display: none;">
-                        <div class="settings-group-title">Whitelist Pages</div>
-                        <small>Add Facebook URLs where PiP should remain enabled</small>
-                        <div class="whitelist-input">
-                            <input type="text" id="whitelistInput" placeholder="facebook.com/page-name">
-                            <button id="addWhitelist">Add</button>
-                        </div>
-                        <div id="whitelistItems" class="whitelist-items">
-                            <!-- Whitelist items will be added dynamically -->
+                        <div class="links">
+                            <button id="addCurrentBtn" class="link-btn">Add current page</button>
+                            <button id="removeCurrentBtn" class="link-btn">Remove current page</button>
                         </div>
                     </div>
+                    <small>Phase 4 will add patterns.</small>
+                    <div id="whitelistItems" class="whitelist-items" aria-live="polite"></div>
                 </div>
             </div>
         </div>
@@ -119,6 +114,12 @@
             <div class="card">
                 <div class="card-title">Send Feedback</div>
                 <div class="feedback-section">
+                    <label class="settings-group-title" for="feedbackCategory">Category</label>
+                    <select id="feedbackCategory" aria-label="Category">
+                        <option>Bug</option>
+                        <option>Idea</option>
+                        <option>Other</option>
+                    </select>
                     <textarea id="feedbackText" placeholder="Share your thoughts, suggestions, or report bugs..." rows="5"></textarea>
                     <button id="sendFeedback" class="btn btn-primary">
                         <i class="fas fa-paper-plane"></i> Send Feedback
@@ -135,7 +136,7 @@
         </div>
     </div>
 
-    <div id="toast" class="toast"></div>
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
     
     <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -4,51 +4,56 @@ document.addEventListener("DOMContentLoaded", () => {
   const tabPauseToggle = document.getElementById("tabToggle");
   const timerSlider = document.getElementById("timerSetting");
   const timerValue = document.getElementById("timerValue");
-  const detectionModeEl = document.getElementById("detectionMode");
-  const whitelistToggle = document.getElementById("whitelistToggle");
-  const whitelistSection = document.getElementById("whitelistSection");
-  const whitelistInput = document.getElementById("whitelistInput");
-  const addWhitelistBtn = document.getElementById("addWhitelist");
   const whitelistItems = document.getElementById("whitelistItems");
   const themeToggle = document.getElementById("themeToggle");
   const navTabs = document.querySelectorAll(".nav-tab");
-  const statusText = document.getElementById("statusText");
-  const statusIcon = document.getElementById("statusIcon");
+  // Phase 2 additions
+  const statusTile = document.getElementById("statusTile");
+  const statusTitle = document.getElementById("statusTitle");
+  const statusSub = document.getElementById("statusSub");
+  const statusTileIcon = document.getElementById("statusTileIcon");
+  const detectionChip = document.getElementById("detectionChip");
+  const applyNote = document.getElementById("applyNote");
+  const whitelistToggleBtn = document.getElementById("whitelistToggleBtn");
+  const modeAuto = document.getElementById("modeAuto");
+  const modeManual = document.getElementById("modeManual");
+  const addCurrentBtn = document.getElementById("addCurrentBtn");
+  const removeCurrentBtn = document.getElementById("removeCurrentBtn");
+  const nonFbHelper = document.getElementById("nonFbHelper");
+  const openFbBtn = document.getElementById("openFbBtn");
 
   // Initialize theme
   initTheme();
 
-  // Load saved settings
-  chrome.storage.local.get(
-    ["isEnabled", "tabPause", "timerInterval", "theme", "whitelistEnabled", "whitelist", "detectionMode", "detectionIntervalMs"],
-    (data) => {
-      // Core settings
+  // Load saved settings + active tab in parallel
+  Promise.all([
+    new Promise(resolve => chrome.tabs.query({ active: true, currentWindow: true }, tabs => resolve(tabs?.[0] || null))),
+    new Promise(resolve => chrome.storage.local.get(["isEnabled", "tabPause", "timerInterval", "theme", "whitelist", "detectionMode", "detectionIntervalMs"], resolve))
+  ]).then(([activeTab, data]) => {
+      const isFacebook = !!(activeTab?.url && /https?:\/\/(www\.)?facebook\.com/i.test(activeTab.url));
+      const currentUrl = activeTab?.url || '';
+
       pipToggle.checked = data.isEnabled || false;
       tabPauseToggle.checked = data.tabPause || false;
-      
-      // Timer settings
+
       const savedInterval = typeof data.detectionIntervalMs === 'number' ? data.detectionIntervalMs : (data.timerInterval || 1000);
       timerSlider.value = savedInterval;
       timerValue.textContent = savedInterval;
 
-      // Detection mode
       const mode = data.detectionMode || 'manual';
-      detectionModeEl.value = mode;
+      (mode === 'auto' ? modeAuto : modeManual).checked = true;
       setManualSliderDisabled(mode === 'auto');
-      
-      // Whitelist settings
-      whitelistToggle.checked = data.whitelistEnabled || false;
-      whitelistSection.style.display = data.whitelistEnabled ? "block" : "none";
-      
-      // Load whitelist items
-      if (data.whitelist && Array.isArray(data.whitelist)) {
-        data.whitelist.forEach(item => addWhitelistItem(item));
-      }
-      
-      // Update status indicators
-      updateStatusIndicator(pipToggle.checked);
-    }
-  );
+
+      renderWhitelistList(data.whitelist);
+      updateWhitelistUiForCurrent(currentUrl, data.whitelist);
+
+      renderStatusTile({ isFacebook, isEnabled: pipToggle.checked, isWhitelisted: isUrlWhitelisted(currentUrl, data.whitelist), mode });
+
+      nonFbHelper.hidden = isFacebook;
+      pipToggle.disabled = !isFacebook;
+      tabPauseToggle.disabled = !isFacebook;
+      whitelistToggleBtn.disabled = !isFacebook;
+  });
 
   // Tab navigation
   navTabs.forEach(tab => {
@@ -80,70 +85,83 @@ document.addEventListener("DOMContentLoaded", () => {
     chrome.storage.local.set({ theme: newTheme });
   });
 
-  // Core toggle handlers
-  pipToggle.addEventListener("change", () => {
-    chrome.storage.local.set({ isEnabled: pipToggle.checked }, () => {
-      updateStatusIndicator(pipToggle.checked);
-      showToast(pipToggle.checked ? "PiP Auto-Close enabled" : "PiP Auto-Close disabled");
-      reloadCurrentTab();
+  // Core toggle handlers with instant apply
+  pipToggle.addEventListener("change", async () => {
+    const isEnabled = pipToggle.checked;
+    chrome.storage.local.set({ isEnabled }, async () => {
+      showToast(isEnabled ? "PiP Auto-Close enabled" : "PiP Auto-Close disabled");
+      renderStatusTile(await computeStatus());
+      const applied = await sendSettingsUpdated({ isEnabled });
+      if (!applied) noteReload();
     });
   });
 
-  tabPauseToggle.addEventListener("change", () => {
-    chrome.storage.local.set({ tabPause: tabPauseToggle.checked }, () => {
-      showToast(tabPauseToggle.checked ? "Tab Pause enabled" : "Tab Pause disabled");
-      reloadCurrentTab();
+  tabPauseToggle.addEventListener("change", async () => {
+    const tabPause = tabPauseToggle.checked;
+    chrome.storage.local.set({ tabPause }, async () => {
+      showToast(tabPause ? "Tab Pause enabled" : "Tab Pause disabled");
+      const applied = await sendSettingsUpdated({ tabPause });
+      if (!applied) noteReload();
     });
   });
 
-  // Timer settings
+  // Timer settings (instant apply)
   timerSlider.addEventListener("input", () => {
     timerValue.textContent = timerSlider.value;
-    chrome.storage.local.set({ timerInterval: Number(timerSlider.value), detectionIntervalMs: Number(timerSlider.value) }, () => {
-      if (pipToggle.checked) {
-        showToast(`Detection interval set to ${timerSlider.value}ms`);
-        reloadCurrentTab();
-      }
+    const detectionIntervalMs = Number(timerSlider.value);
+    chrome.storage.local.set({ timerInterval: detectionIntervalMs, detectionIntervalMs }, async () => {
+      showToast(`Detection interval set to ${timerSlider.value}ms`);
+      await sendSettingsUpdated({ detectionIntervalMs });
     });
   });
 
-  // Detection mode handler
-  detectionModeEl.addEventListener('change', () => {
-    const mode = detectionModeEl.value;
+  // Detection mode radios
+  ;[modeAuto, modeManual].forEach(r => r.addEventListener('change', async () => {
+    const mode = modeAuto.checked ? 'auto' : 'manual';
     setManualSliderDisabled(mode === 'auto');
-    chrome.storage.local.set({ detectionMode: mode }, () => {
+    detectionChip.textContent = `Detection: ${mode === 'auto' ? 'Auto' : 'Manual'}`;
+    chrome.storage.local.set({ detectionMode: mode }, async () => {
       showToast(mode === 'auto' ? 'Detection: Auto (recommended)' : 'Detection: Manual');
-      if (pipToggle.checked) reloadCurrentTab();
+      await sendSettingsUpdated({ detectionMode: mode });
     });
+  }));
+
+  // One-click whitelist toggle for current page
+  whitelistToggleBtn.addEventListener('click', async () => {
+    const { activeTab, whitelist } = await getActiveAndWhitelist();
+    if (!activeTab?.url) return;
+    const currentUrl = activeTab.url;
+    const isWL = isUrlWhitelisted(currentUrl, whitelist);
+    const next = toggleWhitelistEntry(whitelist, currentUrl, !isWL);
+    await new Promise(r => chrome.storage.local.set({ whitelist: next }, r));
+    renderWhitelistList(next);
+    updateWhitelistUiForCurrent(currentUrl, next);
+    renderStatusTile(await computeStatus());
+    await notifyWhitelistChange(currentUrl, !isWL);
+    showToast(!isWL ? 'Added to whitelist' : 'Removed from whitelist');
   });
 
-  // Whitelist functionality
-  whitelistToggle.addEventListener("change", () => {
-    const isEnabled = whitelistToggle.checked;
-    whitelistSection.style.display = isEnabled ? "block" : "none";
-    chrome.storage.local.set({ whitelistEnabled: isEnabled }, () => {
-      showToast(isEnabled ? "Whitelist mode enabled" : "Whitelist mode disabled");
-      if (pipToggle.checked) reloadCurrentTab();
-    });
+  // Settings-tab whitelist links
+  addCurrentBtn.addEventListener('click', async () => {
+    const { activeTab, whitelist } = await getActiveAndWhitelist();
+    if (!activeTab?.url) return;
+    const next = toggleWhitelistEntry(whitelist, activeTab.url, true);
+    await new Promise(r => chrome.storage.local.set({ whitelist: next }, r));
+    renderWhitelistList(next);
+    updateWhitelistUiForCurrent(activeTab.url, next);
+    renderStatusTile(await computeStatus());
+    await notifyWhitelistChange(activeTab.url, true);
   });
 
-  addWhitelistBtn.addEventListener("click", () => {
-    const url = whitelistInput.value.trim();
-    if (!url) return showToast("Please enter a valid URL", "error");
-    
-    chrome.storage.local.get(["whitelist"], (data) => {
-      const whitelist = data.whitelist || [];
-      if (whitelist.includes(url)) {
-        return showToast("This URL is already in the whitelist", "error");
-      }
-      
-      whitelist.push(url);
-      chrome.storage.local.set({ whitelist }, () => {
-        addWhitelistItem(url);
-        whitelistInput.value = "";
-        showToast("URL added to whitelist");
-      });
-    });
+  removeCurrentBtn.addEventListener('click', async () => {
+    const { activeTab, whitelist } = await getActiveAndWhitelist();
+    if (!activeTab?.url) return;
+    const next = toggleWhitelistEntry(whitelist, activeTab.url, false);
+    await new Promise(r => chrome.storage.local.set({ whitelist: next }, r));
+    renderWhitelistList(next);
+    updateWhitelistUiForCurrent(activeTab.url, next);
+    renderStatusTile(await computeStatus());
+    await notifyWhitelistChange(activeTab.url, false);
   });
 
   // Send feedback via Email API
@@ -197,6 +215,13 @@ document.addEventListener("DOMContentLoaded", () => {
         chrome.storage.local.set({ whitelist: newWhitelist }, () => {
           item.remove();
           showToast("URL removed from whitelist");
+          chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
+            const tab = tabs?.[0];
+            if (tab?.id && tab.url && tab.url.includes(urlToRemove)) {
+              await notifyWhitelistChange(tab.url, false);
+              renderStatusTile(await computeStatus());
+            }
+          });
         });
       });
     });
@@ -214,18 +239,75 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 3000);
   }
 
-  function updateStatusIndicator(isEnabled) {
-    if (isEnabled) {
-      statusText.textContent = "Active";
-      statusText.style.color = "var(--success-color)";
-      statusIcon.innerHTML = '<i class="fas fa-shield-alt"></i>';
-      statusIcon.style.color = "var(--success-color)";
+  function isUrlWhitelisted(url, list) {
+    if (!Array.isArray(list)) return false;
+    return list.some(entry => url.includes(entry));
+  }
+
+  function normalizeUrlForWhitelist(raw) {
+    try {
+      const u = new URL(raw);
+      return `${u.origin}${u.pathname}`.replace(/\/$/, '');
+    } catch { return raw; }
+  }
+
+  function toggleWhitelistEntry(whitelist, url, add) {
+    const entry = normalizeUrlForWhitelist(url);
+    const list = Array.isArray(whitelist) ? [...whitelist] : [];
+    const exists = list.some(i => i === entry || url.includes(i));
+    if (add) {
+      if (!exists) list.push(entry);
     } else {
-      statusText.textContent = "Inactive";
-      statusText.style.color = "var(--danger-color)";
-      statusIcon.innerHTML = '<i class="fas fa-shield-alt fa-slash"></i>';
-      statusIcon.style.color = "var(--danger-color)";
+      return list.filter(i => i !== entry);
     }
+    return list;
+  }
+
+  async function getActiveAndWhitelist() {
+    const [tabs, store] = await Promise.all([
+      new Promise(r => chrome.tabs.query({ active: true, currentWindow: true }, r)),
+      new Promise(r => chrome.storage.local.get(['whitelist'], r)),
+    ]);
+    return { activeTab: tabs?.[0] || null, whitelist: store.whitelist || [] };
+  }
+
+  function updateWhitelistUiForCurrent(url, whitelist) {
+    const isWL = isUrlWhitelisted(url, whitelist);
+    whitelistToggleBtn.textContent = isWL ? 'Remove from whitelist' : 'Allow PiP on this page';
+  }
+
+  function renderWhitelistList(list) {
+    whitelistItems.innerHTML = '';
+    (Array.isArray(list) ? list : []).forEach(url => addWhitelistItem(url));
+  }
+
+  async function computeStatus() {
+    const [tabs, store] = await Promise.all([
+      new Promise(r => chrome.tabs.query({ active: true, currentWindow: true }, r)),
+      new Promise(r => chrome.storage.local.get(['isEnabled','detectionMode','whitelist']), r)
+    ]);
+    const tab = tabs?.[0];
+    const isFacebook = !!(tab?.url && /https?:\/\/(www\.)?facebook\.com/i.test(tab.url));
+    const isWhitelisted = isUrlWhitelisted(tab?.url || '', store.whitelist || []);
+    return { isFacebook, isEnabled: !!store.isEnabled, isWhitelisted, mode: store.detectionMode || 'manual', url: tab?.url || '' };
+  }
+
+  function renderStatusTile({ isFacebook, isEnabled, isWhitelisted, mode }) {
+    const active = isFacebook && isEnabled && !isWhitelisted;
+    if (isWhitelisted) {
+      statusTitle.textContent = 'OFF on this page (whitelisted)';
+      statusTileIcon.className = 'fas fa-ban';
+      statusTile.style.borderColor = 'var(--border-color)';
+    } else if (active) {
+      statusTitle.textContent = 'Protected: ON';
+      statusTileIcon.className = 'fas fa-shield-alt';
+      statusTile.style.borderColor = 'var(--success-color)';
+    } else {
+      statusTitle.textContent = 'Protection: OFF';
+      statusTileIcon.className = 'fas fa-shield-alt fa-slash';
+      statusTile.style.borderColor = 'var(--danger-color)';
+    }
+    detectionChip.textContent = `Detection: ${mode === 'auto' ? 'Auto' : 'Manual'}`;
   }
 
   function initTheme() {
@@ -243,4 +325,36 @@ document.addEventListener("DOMContentLoaded", () => {
     timerSlider.disabled = disabled;
     timerSlider.classList.toggle('disabled', disabled);
   }
+
+  async function sendSettingsUpdated(patch) {
+    const tabs = await new Promise(r => chrome.tabs.query({ active: true, currentWindow: true }, r));
+    const tab = tabs?.[0];
+    if (!tab?.id) return false;
+    try {
+      const res = await chrome.tabs.sendMessage(tab.id, { type: 'SETTINGS_UPDATED', payload: patch });
+      return !!(res && res.ok);
+    } catch { return false; }
+  }
+
+  async function notifyWhitelistChange(url, isWhitelisted) {
+    const tabs = await new Promise(r => chrome.tabs.query({ active: true, currentWindow: true }, r));
+    const tab = tabs?.[0];
+    if (!tab?.id) return false;
+    try {
+      const res = await chrome.tabs.sendMessage(tab.id, { type: 'WHITELIST_STATUS_CHANGED', url, isWhitelisted });
+      return !!(res && res.ok);
+    } catch { return false; }
+  }
+
+  function noteReload() {
+    applyNote.hidden = false;
+    requestAnimationFrame(() => {
+      setTimeout(() => { applyNote.hidden = true; }, 2500);
+    });
+  }
+
+  // Non-Facebook helper
+  openFbBtn?.addEventListener('click', () => {
+    chrome.tabs.create({ url: 'https://www.facebook.com/' });
+  });
 });

--- a/style.css
+++ b/style.css
@@ -459,3 +459,68 @@ input[type="range"]::-webkit-slider-thumb {
 .version {
     font-style: italic;
 }
+
+/* Status tile */
+.status-tile {
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 12px;
+    margin-bottom: 12px;
+}
+.status-icon-wrap {
+    display: grid;
+    place-items: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--toggle-bg);
+    color: var(--accent-color);
+}
+.status-title {
+    font-weight: 700;
+}
+.status-sub { font-size: 12px; opacity: .8; }
+.chip {
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: var(--toggle-bg);
+    color: var(--text-color);
+    font-size: 12px;
+}
+.apply-note { font-size: 12px; color: var(--accent-color); margin-bottom: 8px; }
+.helper { font-size: 12px; opacity: .9; margin-top: 8px; display: flex; align-items: center; gap: 8px; }
+
+/* Radio styles */
+.radio { display: inline-flex; align-items: center; gap: 8px; margin-right: 12px; cursor: pointer; }
+.radio input { accent-color: var(--accent-color); }
+
+/* Link-like buttons */
+.links { display: flex; gap: 10px; }
+.link-btn { background: none; border: none; padding: 0; color: var(--accent-color); cursor: pointer; }
+.link-btn:hover { text-decoration: underline; }
+
+/* Accessible focus */
+button:focus, input:focus, select:focus { outline: 2px solid var(--accent-color); outline-offset: 2px; }
+
+/* Select generic style reuse (feedback category) */
+#feedbackCategory {
+    display: block;
+    width: 100%;
+    min-height: 36px;
+    padding: 8px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--input-bg);
+    color: var(--text-color);
+    font: inherit;
+    font-size: 14px;
+    margin-bottom: 8px;
+}
+
+/* Non-Facebook helper */
+#nonFbHelper { margin-top: 8px; }


### PR DESCRIPTION
## v1.1 Phase 2: Popup redesign – fast controls, status, and usability polish

### Problem statement
Redesign the popup to make core actions obvious and fast. Provide a modern, lightweight UI with a clear status indicator, primary toggles, and a one-click “Allow on this page” control. Ensure the UI loads quickly, is keyboard-accessible, and applies changes without a full page reload where feasible.

### What’s in this PR
1) Popup IA and layout (3 tabs)
- Main: new status tile with ON/OFF/Whitelisted, detection chip, PiP Auto-Close + Pause toggles, one-click whitelist button, disabled Snooze (tooltip).
- Settings: Detection Speed radios (Auto/Manual), slider disabled in Auto with helper text, basic whitelist manager (Add current/Remove current) and list.
- Feedback: adds Category dropdown (Bug/Idea/Other) to existing flow.

2) Instant apply behavior
- Popup sends runtime messages to content script to apply isEnabled/tabPause/detectionMode/detectionIntervalMs live when possible.
- Whitelist add/remove for current page updates immediately and notifies content script to stop/start observers without reload.
- If live apply is not possible, a non-blocking note appears: “Changes applied after reload.”

3) State management and wiring
- Persists detectionMode, detectionIntervalMs, autoCloseEnabled (isEnabled), pauseOnTabSwitch (tabPause), and whitelist.
- Loads state + active tab in parallel to render quickly; minimal DOM writes.

4) Visual and accessibility polish
- CSS variables + focus outlines; accessible labels; logical tab order.
- Non-Facebook helper: disables actions and offers “Open Facebook”.

### Files changed
- popup.html: New layout and controls per spec; accessible attributes.
- popup.js: Instant apply wiring, whitelist quick controls, status tile logic, category in feedback.
- style.css: Status tile, chips, radios, link buttons, focus outlines; reuses theme tokens.
- content.js: Adds listeners for SETTINGS_UPDATED and WHITELIST_STATUS_CHANGED to support instant apply (from Phase 1 base).
- background.js, manifest.json: No changes required for Phase 2.

### Acceptance criteria coverage
- Load ≤ 150ms (DOM writes batched; minimal work in init; no heavy assets).
- Status tile reflects ON/OFF/Whitelisted for active tab.
- Toggles attempt live apply; fallback note appears if content script can't apply live.
- One-click whitelist updates immediately and updates status tile.
- Detection mode UI: radios control; slider disabled in Auto; persists values.
- Keyboard navigation and ARIA labels added; contrast preserved.
- No new permissions.

### Testing
- Open popup on facebook.com and verify status tile and controls behavior.
- Toggle settings; confirm instant apply or fallback note.
- Add/remove current page to whitelist from Main and Settings tabs; status updates immediately.
- Open on non-facebook.com; controls disabled; button opens Facebook.

### Notes
- Snooze is intentionally disabled with a tooltip for Phase 3.
- Pattern-based whitelist planned for Phase 4.
